### PR TITLE
Fixed setup to be independent on the path of current virtualenv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,10 @@
 #!/bin/env python
 from distutils.core import setup, Extension
-from os import environ
+import numpy as np
 
 pysais = Extension('pysais',
     sources = ['sais.c', 'pysais.c'],
-    #libraries = ['gsl', 'gslcblas'],
-    library_dirs = ['/home/nfs/alexeygritsenk/env/sys_enhance/lib64/'])
+    )
 
 setup(name = 'Py-SAIS',
       version = '0.1',
@@ -13,5 +12,5 @@ setup(name = 'Py-SAIS',
       author = 'Alexey A. Gritsenko',
       author_email = 'a.gritsenko@tudelft.nl',
       long_description = 'A Python module wrapper for the SA-IS algorithm implementation by Yuta Mori.',
-      include_dirs = ['/home/nfs/alexeygritsenk/env/sys_enhance/include/python2.7/', '/home/nfs/alexeygritsenk/env/sys_enhance/lib64/python2.7/site-packages/numpy/core/include/numpy/', '/home/nfs/alexeygritsenk/env/sys_enhance/include/'],
+      include_dirs = [np.get_include() + '/numpy'],
       ext_modules = [pysais])


### PR DESCRIPTION
I fixed the setup to be independent on your current path of virtualenv, with your username. If I reduced it too much then add again what is necessary for you please.

I expected that most of removed items are residues from experiments, until setup started to work for you.
