### PR TITLE
add unittest for sais_int and lcp_int

### DIFF
--- a/tests/pysais_test.py
+++ b/tests/pysais_test.py
@@ -3,6 +3,7 @@
 
 import pysais
 import unittest
+import numpy
 
 
 class TestPySAIS(unittest.TestCase):
@@ -11,13 +12,29 @@ class TestPySAIS(unittest.TestCase):
         None
 
     def test_mississippi(self):
+
+        # with strings
         t = 'mississippi'
         sa = pysais.sais(t)
         lcp, lcp_lm, lcp_mr = pysais.lcp(t, sa)
-        self.assertEquals([10, 7, 4, 1, 0, 9, 8, 6, 3, 5, 2],
-                          [x for x in sa])
-        self.assertEquals([1, 1, 4, 0, 0, 1, 0, 2, 1, 3, 0],
-                          [x for x in lcp])
+
+        # with ints
+        # the following array encodes mississipi with the following sorted
+        # character mapping: i=0, m=1, p=2, s=3
+        # the following array
+        t_int = numpy.array([1, 0, 3, 3, 0, 3, 3, 0, 2, 2, 0],
+                            dtype=numpy.int32)
+        sa_int = pysais.sais_int(t_int, 4)
+        lcp_int, lcp_lm_int, lcp_mr_int = pysais.lcp_int(t_int, sa_int)
+
+        # the expected outputs are the same in both cases
+        expected_sa = [10, 7, 4, 1, 0, 9, 8, 6, 3, 5, 2]
+        expected_lcp = [1, 1, 4, 0, 0, 1, 0, 2, 1, 3, 0]
+
+        self.assertEquals(expected_sa, [x for x in sa])
+        self.assertEquals(expected_sa, [x for x in sa_int])
+        self.assertEquals(expected_lcp, [x for x in lcp])
+        self.assertEquals(expected_lcp, [x for x in lcp_int])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR provides a unittest that highlight the bug with `lcp_int` mentionned in https://github.com/AlexeyG/PySAIS/issues/11 . (it should not be merged).

https://github.com/AlexeyG/PySAIS/pull/13 provides the fix (also includes the test, which proves the bugfix).